### PR TITLE
Automatiza agregar píldoras desde issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/pildora.yml
+++ b/.github/ISSUE_TEMPLATE/pildora.yml
@@ -3,6 +3,11 @@ description: Propuesta para una nueva píldora formativa
 title: "[Píldora] Título breve"
 labels: [píldora]
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Arrastra y suelta una imagen en la descripción; la acción la descargará y
+        la renombrará automáticamente usando la fecha proporcionada.
   - type: input
     id: fecha
     attributes:
@@ -14,16 +19,18 @@ body:
   - type: input
     id: url
     attributes:
-      label: Enlace relevante
-      description: Proporcione el enlace relacionado con la píldora.
+      label: Enlace relevante (opcional)
+      description: Proporcione el enlace relacionado con la píldora. Si se omite, se intentará extraer el primero de la descripción.
       placeholder: "https://ejemplo.com"
     validations:
-      required: true
+      required: false
   - type: textarea
     id: descripcion
     attributes:
       label: Descripción
-      description: Escribe la descripción de la píldora en formato Markdown.
+      description: |
+        Escribe la descripción de la píldora en formato Markdown. Puedes
+        arrastrar una imagen aquí para adjuntarla.
       placeholder: "Escribe aquí la descripción"
     validations:
       required: true

--- a/.github/workflows/pildora.yml
+++ b/.github/workflows/pildora.yml
@@ -20,37 +20,60 @@ jobs:
 
       - name: Procesar la Issue
         id: process
+        env:
+          BODY: ${{ github.event.issue.body }}
         run: |
+          set -e
           # Extraer datos del cuerpo de la issue
-          FECHA=$(echo "${{ github.event.issue.body }}" | grep -oP "(?<=Fecha de la píldora:\n\n).*")
-          URL=$(echo "${{ github.event.issue.body }}" | grep -oP "(?<=Enlace relevante:\n\n).*")
-          DESCRIPCION=$(echo "${{ github.event.issue.body }}" | sed -n '/Descripción:/,$p' | sed '1d')
+          FECHA=$(echo "$BODY" | awk '/Fecha de la/{getline; while($0==""){getline}; print}')
 
-          # Verificar y renombrar la imagen
-          IMAGEN=$(find . -name "*.jpg" -o -name "*.png" | head -n 1)
-          if [ -z "$IMAGEN" ]; then
-            IMAGEN="null"
-          else
-            EXT="${IMAGEN##*.}"
-            mv "$IMAGEN" "images/$FECHA.$EXT"
-            IMAGEN="$FECHA.$EXT"
+          URL=$(echo "$BODY" | awk '/Enlace relevante/{getline; while($0==""){getline}; print}')
+          [ "$URL" = "_No response_" ] && URL=""
+
+          DESCRIPCION=$(echo "$BODY" | awk '/Descripción/{flag=1; next} flag{print}' | grep -v '^$' | grep -vF '![' | grep -v '<img')
+
+          if [ -z "$URL" ]; then
+            URL=$(echo "$DESCRIPCION" | grep -oP 'https?://\\S+' | head -n1)
+          fi
+          [ -z "$URL" ] && URL="null"
+
+          IMAGE_URL=$(echo "$BODY" | sed -nE 's/.*!?\\[[^]]*\\]\\((https?:[^) ]+)\\).*/\1/p' | head -n1)
+          if [ -z "$IMAGE_URL" ]; then
+            IMAGE_URL=$(echo "$BODY" | sed -nE 's/.*<img[^>]+src="([^" >]+)".*/\1/p' | head -n1)
           fi
 
-          # Crear entrada YAML
+          if [ -n "$IMAGE_URL" ]; then
+            MIME=$(curl -sI "$IMAGE_URL" | grep -i '^content-type:' | tr -d '\r' | awk '{print $2}' | cut -d';' -f1)
+            EXT=${MIME##*/}
+            [ "$EXT" = "jpeg" ] && EXT=jpg
+            curl -L "$IMAGE_URL" -o "images/$FECHA.$EXT"
+            IMAGEN="$FECHA.$EXT"
+          else
+            IMAGEN="null"
+          fi
+
           echo "- date: '$FECHA'" > entry.yml
           echo "  image: $IMAGEN" >> entry.yml
           echo "  url: $URL" >> entry.yml
           echo "  description: |" >> entry.yml
           echo "$DESCRIPCION" | sed 's/^/    /' >> entry.yml
 
+          echo "FECHA=$FECHA" >> $GITHUB_OUTPUT
+          echo "IMAGEN=$IMAGEN" >> $GITHUB_OUTPUT
 
       - name: Actualizar el archivo data.yml
         run: |
+          printf '\n' >> data.yml
           cat entry.yml >> data.yml
 
       - name: Hacer commit y push
+        env:
+          FECHA: ${{ steps.process.outputs.FECHA }}
+          IMAGEN: ${{ steps.process.outputs.IMAGEN }}
         run: |
-          git add data.yml images/
+          git add data.yml
+          if [ "$IMAGEN" != "null" ]; then
+            git add "images/$IMAGEN"
+          fi
           git commit -m "Agregar píldora del $FECHA"
           git push
-


### PR DESCRIPTION
## Summary
- Se filtran líneas en blanco o con imágenes de la descripción, evitando errores de `grep`
- Se obtienen las URLs de imágenes con `sed`, soportando Markdown y etiquetas `<img>`, y se depura el `Content-Type` al descargarla

## Testing
- `pip install pyyaml`
- `python - <<'PY'
import yaml
for f in ['.github/workflows/pildora.yml','.github/ISSUE_TEMPLATE/pildora.yml']:
    yaml.safe_load(open(f))
print('YAML OK')
PY`


------
https://chatgpt.com/codex/tasks/task_e_68bb5781b1e483229b3057bbb7392ad2