### PR TITLE
Generate static per-date pages with OG metadata

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,41 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Build pages
+        run: |
+          make build
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./public
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - id: deploy
+        uses: actions/deploy-pages@v4
+

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 public/
 .DS_Store
 **/.DS_Store
+# Generated per-date pages
+20??-??-??/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-.PHONY: serve
+.PHONY: serve build
+
+build:
+	./generate_pages.py public
 
 serve:
-	python3 -m http.server 8000
+	python3 -m http.server -d public 8000

--- a/README.md
+++ b/README.md
@@ -17,11 +17,17 @@ Cada viernes comparto una "píldora formativa": un recurso digital interesante, 
 ## 🚀 Uso
 
 1. Clona este repositorio
-2. Ejecuta el servidor local:
+2. Genera las páginas estáticas (se guardarán en `public/`):
+   ```bash
+   make build
+   ```
+3. Ejecuta el servidor local:
    ```bash
    make serve
    ```
-3. Abre http://localhost:8000 en tu navegador
+4. Abre http://localhost:8000 en tu navegador
+
+Las páginas per-fecha se generan durante el despliegue mediante GitHub Actions, por lo que no se almacenan en el repositorio.
 
 ## 🔍 Búsqueda
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -12,13 +12,19 @@ function escapeHtml(text) {
 }
 
 function getBasePath() {
-    return window.location.pathname.replace(/\/[^/]*$/, '/');
+    const base = document.querySelector('base');
+    return base ? base.getAttribute('href') : '/';
+}
+
+function getDateFromPath() {
+    const match = window.location.pathname.match(/\/(\d{4}-\d{2}-\d{2})\/?$/);
+    return match ? match[1] : null;
 }
 
 function getCurrentWeekPildora(pildoras) {
-    // Verificar si hay una fecha en la URL
+    // Verificar si hay una fecha en la URL o en la ruta
     const urlParams = new URLSearchParams(window.location.search);
-    const dateParam = urlParams.get('date');
+    const dateParam = urlParams.get('date') || getDateFromPath();
     
     if (dateParam) {
         // Si hay fecha en la URL, mostrar esa píldora independientemente de la fecha
@@ -56,7 +62,7 @@ function sharePildora(date) {
     if (!pildora) return;
 
     const baseUrl = window.location.origin + getBasePath();
-    const shareUrl = `${baseUrl}?date=${date}`;
+    const shareUrl = `${baseUrl}${date}/`;
     const imageUrl = pildora.image ? `${baseUrl}images/${pildora.image}` : '';
     
     // Preparar el texto a compartir
@@ -118,12 +124,12 @@ function updateMetaTags(pildora) {
     document.querySelector('meta[property="og:title"]').setAttribute('content', 'Píldora Formativa del ' + pildora.date);
     document.querySelector('meta[property="og:description"]').setAttribute('content', escapeHtml(pildora.description.split('\n')[0]));
     document.querySelector('meta[property="og:image"]').setAttribute('content', imageUrl);
-    document.querySelector('meta[property="og:url"]').setAttribute('content', window.location.href);
+    document.querySelector('meta[property="og:url"]').setAttribute('content', baseUrl + pildora.date + '/');
 }
 
 async function loadPildoras() {
     try {
-        const response = await fetch('data.yml');
+        const response = await fetch('/data.yml');
         const yamlText = await response.text();
         const data = jsyaml.load(yamlText);
         // Guardar los datos globalmente para acceder desde otras funciones
@@ -159,7 +165,7 @@ async function loadPildoras() {
                             <div class="text-muted small mb-2">${highlightText(new Date(pildora.date).toLocaleDateString('es-ES', { day: 'numeric', month: 'long', year: 'numeric' }), searchTerm)}</div>
                             <div class="card-text">${marked.parse(highlightText(escapeHtml(pildora.description), searchTerm))}</div>
                             <div class="d-flex justify-content-between mt-3">
-                                <a href="${getBasePath()}?date=${pildora.date}" class="btn btn-primary">Ver píldora</a>
+                                <a href="${getBasePath()}${pildora.date}/" class="btn btn-primary">Ver píldora</a>
                                 ${pildora.url ? `<a href="${pildora.url}" class="btn btn-secondary" target="_blank">Visitar enlace</a>` : ''}
                                 <button class="btn btn-outline-secondary" onclick="sharePildora('${pildora.date}')">
                                     <i class="bi bi-share"></i> Compartir

--- a/generate_pages.py
+++ b/generate_pages.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+import os
+import re
+import shutil
+import html
+import yaml
+import sys
+
+BASE_URL = "https://pildoras.ernesto.es/"
+ROOT = os.path.dirname(os.path.abspath(__file__))
+OUTPUT_DIR = os.path.join(ROOT, sys.argv[1]) if len(sys.argv) > 1 else ROOT
+
+def load_data():
+    with open(os.path.join(ROOT, 'data.yml'), 'r', encoding='utf-8') as f:
+        data = yaml.safe_load(f)
+    return data.get('pildoras', [])
+
+def prepare_output_dir():
+    if OUTPUT_DIR != ROOT:
+        if os.path.exists(OUTPUT_DIR):
+            shutil.rmtree(OUTPUT_DIR)
+        os.makedirs(OUTPUT_DIR, exist_ok=True)
+        for item in ['index.html', 'assets', 'images', 'data.yml', '.nojekyll', 'CNAME']:
+            src = os.path.join(ROOT, item)
+            dst = os.path.join(OUTPUT_DIR, item)
+            if os.path.isdir(src):
+                shutil.copytree(src, dst)
+            elif os.path.isfile(src):
+                shutil.copy2(src, dst)
+
+def clean_output():
+    pattern = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+    for name in os.listdir(OUTPUT_DIR):
+        if pattern.match(name) and os.path.isdir(os.path.join(OUTPUT_DIR, name)):
+            shutil.rmtree(os.path.join(OUTPUT_DIR, name))
+
+template = """<!DOCTYPE html>
+<html lang=\"es\">
+<head>
+    <meta charset=\"UTF-8\">
+    <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">
+    <base href=\"/\">
+    <meta property=\"og:title\" content=\"Píldora Formativa del {date}\">
+    <meta property=\"og:description\" content=\"{description}\">
+    <meta property=\"og:image\" content=\"{image_url}\">
+    <meta property=\"og:url\" content=\"{base_url}{date}/\">
+    <meta name=\"twitter:card\" content=\"summary_large_image\">
+    <title>Píldora Formativa del {date}</title>
+    <link rel=\"icon\" href=\"data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>💊</text></svg>\">
+    <link href=\"https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css\" rel=\"stylesheet\">
+    <link rel=\"stylesheet\" href=\"assets/css/main.css\">
+    <script src=\"https://cdnjs.cloudflare.com/ajax/libs/js-yaml/4.1.0/js-yaml.min.js\"></script>
+    <script src=\"https://cdn.jsdelivr.net/npm/marked/marked.min.js\"></script>
+</head>
+<body class=\"bg-light\">
+    <a href=\"https://github.com/erseco/pildora_del_viernes\" class=\"github-ribbon\">
+        <img width=\"149\" height=\"149\" src=\"https://github.blog/wp-content/uploads/2008/12/forkme_right_darkblue_121621.png\" alt=\"Fork me on GitHub\" loading=\"lazy\">
+    </a>
+    <div class=\"container py-4\">
+        <h1 class=\"text-center mb-4\">💊 Píldoras del Viernes <small class=\"text-muted fs-6\">(<span id=\"pildoraCount\">0</span> píldoras)</small></h1>
+        <div class=\"row justify-content-center mb-4\">
+            <div class=\"col-md-6 d-none\" id=\"searchContainer\">
+                <div class=\"input-group\">
+                    <input type=\"text\" id=\"searchInput\" class=\"form-control\" placeholder=\"Buscar píldoras...\">
+                    <a href=\"https://github.com/erseco/pildora_del_viernes/issues/new?title=Nueva%20píldora&labels=enhancement&body=**Descripción:**%0A%0A**Fecha%20propuesta:**%0A%0A**URL:**%0A%0A**Imagen:**%20_(adjuntar%20o%20incluir%20enlace)_\" class=\"btn btn-outline-primary\" target=\"_blank\">
+                        <i class=\"bi bi-plus-circle\"></i> Sugerir nueva píldora
+                    </a>
+                </div>
+            </div>
+            <div class=\"col-md-6 text-center\" id=\"viewAllContainer\">
+                <a href=\"/\" class=\"btn btn-primary\">Ver todas las píldoras</a>
+            </div>
+        </div>
+        <div class=\"row\" id=\"pildorasContainer\"></div>
+        <footer class=\"text-center mt-4 pb-4 text-muted\">
+            <p>Designed with ❤️ from a remote island</p>
+            <p>2025 © Ernesto Serrano · <a href=\"https://github.com/erseco/pildora_del_viernes\" class=\"text-muted\"><i class=\"bi bi-github\"></i> Código fuente</a></p>
+        </footer>
+    </div>
+    <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css\">
+    <script src=\"https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js\"></script>
+    <script src=\"assets/js/main.js\"></script>
+</body>
+</html>
+"""
+
+def generate():
+    pildoras = load_data()
+    prepare_output_dir()
+    clean_output()
+    for p in pildoras:
+        date = p.get('date')
+        description = html.escape(p.get('description', '').replace('\n', ' '))
+        image = p.get('image')
+        image_url = f"{BASE_URL}images/{image}" if image else ''
+        dir_path = os.path.join(OUTPUT_DIR, date)
+        os.makedirs(dir_path, exist_ok=True)
+        with open(os.path.join(dir_path, 'index.html'), 'w', encoding='utf-8') as f:
+            f.write(template.format(date=date, description=description, image_url=image_url, base_url=BASE_URL))
+
+if __name__ == '__main__':
+    generate()

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <base href="/">
     <meta property="og:title" content="💊 Píldoras del Viernes">
     <meta property="og:description" content="Píldora formativa semanal">
     <meta property="og:image" content="">


### PR DESCRIPTION
## Summary
- ignore dated folders and remove previously committed pages
- allow `generate_pages.py` to output to a `public/` directory and copy site assets
- add GitHub Actions workflow to build and deploy the static pages

## Testing
- `make build`


------
https://chatgpt.com/codex/tasks/task_e_68bb6754726483228d60ddad44b04fc3