### PR TITLE
Show full pill text in Open Graph description

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -122,7 +122,10 @@ function updateMetaTags(pildora) {
     const imageUrl = baseUrl + 'images/' + pildora.image;
 
     document.querySelector('meta[property="og:title"]').setAttribute('content', 'Píldora Formativa del ' + pildora.date);
-    document.querySelector('meta[property="og:description"]').setAttribute('content', escapeHtml(pildora.description.split('\n')[0]));
+    document.querySelector('meta[property="og:description"]').setAttribute(
+        'content',
+        escapeHtml(pildora.description.replace(/\n/g, ' '))
+    );
     document.querySelector('meta[property="og:image"]').setAttribute('content', imageUrl);
     document.querySelector('meta[property="og:url"]').setAttribute('content', baseUrl + pildora.date + '/');
 }


### PR DESCRIPTION
## Summary
- Ensure Open Graph description uses the entire pill text without truncation

## Testing
- `make build`


------
https://chatgpt.com/codex/tasks/task_e_68bb70d082b08322b881f90b9e2e3dec