### PR TITLE
Refine share text and OpenGraph metadata

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -72,14 +72,13 @@ function sharePildora(date) {
         year: 'numeric' 
     });
     
-    const shareText = `Píldora formativa del ${formattedDate}:\n\n${pildora.description}\n\nVer más en: ${shareUrl}`;
-    
+    const shareText = `${pildora.description}\n\nVer más en: ${shareUrl}`;
+
     if (navigator.share) {
         // Preparar objeto de compartir
         const shareData = {
-            title: `Píldora Formativa del ${formattedDate}`,
-            text: shareText,
-            url: shareUrl
+            title: pildora.description,
+            text: shareText
         };
 
         // Si hay imagen, añadirla al objeto de compartir
@@ -121,8 +120,7 @@ function updateMetaTags(pildora) {
     const baseUrl = window.location.origin + getBasePath();
     const imageUrl = baseUrl + 'images/' + pildora.image;
 
-    document.querySelector('meta[property="og:title"]').setAttribute('content', 'Píldora Formativa del ' + pildora.date);
-    document.querySelector('meta[property="og:description"]').setAttribute(
+    document.querySelector('meta[property="og:title"]').setAttribute(
         'content',
         escapeHtml(pildora.description.replace(/\n/g, ' '))
     );

--- a/generate_pages.py
+++ b/generate_pages.py
@@ -40,8 +40,7 @@ template = """<!DOCTYPE html>
     <meta charset=\"UTF-8\">
     <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">
     <base href=\"/\">
-    <meta property=\"og:title\" content=\"Píldora Formativa del {date}\">
-    <meta property=\"og:description\" content=\"{description}\">
+    <meta property=\"og:title\" content=\"{description}\">
     <meta property=\"og:image\" content=\"{image_url}\">
     <meta property=\"og:url\" content=\"{base_url}{date}/\">
     <meta name=\"twitter:card\" content=\"summary_large_image\">


### PR DESCRIPTION
## Summary
- Share button now uses the pill's description as the title and message
- Removed duplicated link in shared text
- OpenGraph title now uses the pill description and drops the description tag to avoid truncation

## Testing
- `python -m py_compile generate_pages.py`
- `make build`


------
https://chatgpt.com/codex/tasks/task_e_68bb779afa7c83229888b01e640afa34